### PR TITLE
Fix issue with bad interpolation

### DIFF
--- a/Config/PluginConfig.cs
+++ b/Config/PluginConfig.cs
@@ -1,3 +1,4 @@
+using CounterStrikeSharp.API.Modules.Utils;
 using CounterStrikeSharp.API.Core;
 
 namespace AdvancedTeamBalance

--- a/Config/PluginConfig.cs
+++ b/Config/PluginConfig.cs
@@ -19,7 +19,7 @@ namespace AdvancedTeamBalance
         /// <summary>
         /// Tag shown in chat messages
         /// </summary>
-        public string PluginTag { get; set; } = "{red}[TeamBalance]{default}";
+        public string PluginTag { get; set; } = $"{ChatColors.Red}[TeamBalance]{ChatColors.Default}";
         
         /// <summary>
         /// Minimum number of players required for balancing to activate


### PR DESCRIPTION
The interpolation used in this file `Config/PluginConfig.cs` is wrong.
We can simplify it using the utility module for chat colors provided by Counter Strike Sharp.

The build passed succesfully.

![Capture d'écran 2025-05-24 110802](https://github.com/user-attachments/assets/475f9cb4-482d-4b1f-a9c2-59ddc4ee372a)
